### PR TITLE
If tests timeout try and cleanup test deploy

### DIFF
--- a/test/commands/index.test.ts
+++ b/test/commands/index.test.ts
@@ -1,27 +1,38 @@
 import {expect, test} from '@oclif/test'
 import * as crypto from 'crypto'
+import Site from '../../src/site'
 
 const str = crypto.randomBytes(2).toString('hex')
+const name = `test-${str}`
 
-describe('deploy', () => {
-  test
-  .stderr()
-  .command(['deploy', `test-${str}`, '--dir', 'test/dist'])
-  .it('runs deploy cmd', ctx => {
-    let regex = new RegExp(`Site not found: test-${str}-.*`)
-    expect(ctx.stderr).to.match(regex)
-    regex = new RegExp(`Site created: http://test-${str}-.*.netlify.app`)
-    expect(ctx.stderr).to.match(regex)
-    regex = new RegExp(`Deployed: http://test-${str}-.*.netlify.app`)
-    expect(ctx.stderr).to.match(regex)
+describe('commands', () => {
+  after(async function () {
+    // if 'delete' fails try deleting again here
+    return new Site(name, (msg, ...args) => {
+      console.log(`(after hook) ${msg}`, ...args)
+    }).delete()
   })
-})
 
-describe('delete', () => {
-  test
-  .stderr()
-  .command(['delete', `test-${str}`])
-  .it('runs delete cmd', ctx => {
-    expect(ctx.stderr).to.match(new RegExp(`Site deleted: http://test-${str}-.*.netlify.app`))
+  describe('deploy', () => {
+    test
+    .stderr()
+    .command(['deploy', name, '--dir', 'test/dist'])
+    .it('runs deploy cmd', ctx => {
+      let regex = new RegExp(`Site not found: test-${str}-.*`)
+      expect(ctx.stderr).to.match(regex)
+      regex = new RegExp(`Site created: http://test-${str}-.*.netlify.app`)
+      expect(ctx.stderr).to.match(regex)
+      regex = new RegExp(`Deployed: http://test-${str}-.*.netlify.app`)
+      expect(ctx.stderr).to.match(regex)
+    })
+  })
+
+  describe('delete', () => {
+    test
+    .stderr()
+    .command(['delete', name])
+    .it('runs delete cmd', ctx => {
+      expect(ctx.stderr).to.match(new RegExp(`Site deleted: http://test-${str}-.*.netlify.app`))
+    })
   })
 })


### PR DESCRIPTION
Timeouts on the site delete test cause test deploy not to be deleted.
Retry site deletion in the after hook.