### PR TITLE
Remove github workflow concurrency

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   Test:
-    concurrency: 'netlify-git-branch-github-workflow'
+    concurrency: ${{ github.ref }}
     name: Test
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
Not really what I want as cancels any pending jobs. What I want is
global wait behaviour by using a single concurrency group but not
the cancel behaviour.

So instead trying concurrency group per jobs in single PR intention is
to run jobs serially to reduce frequency of netlfiy HTTP requests and
avoid throttling.